### PR TITLE
updated swapLimit

### DIFF
--- a/aggregator/aggregator.ride
+++ b/aggregator/aggregator.ride
@@ -53,8 +53,11 @@ func swapWX(asset0: String, asset1: String, amount0: Int) = {
 func swapLimit(params: String, t0Str: String, t1Str: String) = {
     func doLimit(asset: ByteVector|Unit, orderParams: String) = {
         let ord = orderParams.split(">")
-        let (orderId, orderAmount) = (ord[0], ord[1])
-        strict inv = invoke(Address(limitContract.fromBase58String()),"fulfillOrder",[orderId],[AttachedPayment(asset, orderAmount.parseIntValue())]) 
+        let (orderId, orderAmountStr) = (ord[0], ord[1])
+        let _orderAmount = orderAmountStr.parseIntValue()
+        strict assetBal = getBalance(asset)
+        let orderAmount = if (assetBal < _orderAmount) then assetBal else _orderAmount
+        strict inv = invoke(Address(limitContract.fromBase58String()),"fulfillOrder",[orderId],[AttachedPayment(asset, orderAmount)]) 
         asset
     }
     let ordersLi = params.split(":")


### PR DESCRIPTION
Add checking balance before limit swaps to avoid fails if after previous swap there was a bit lower value, then calculated by aggregator